### PR TITLE
Ignore messages on shared topic when not authenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![test workflow](https://github.com/zpieslak/mobilus-client/actions/workflows/test.yml/badge.svg)
 
-This code provides a native Python client for the Mobilus Cosmo GTW. It connects directly to the gateway's MQTT broker and sends message commands to control the associated devices. The connection is established locally, so the client must be run on the same network as the gateway. Currently, the only tested and supported devices are radio shutters (Mobilus COSMO 2WAY).
+This code provides a native Python client for the Mobilus Cosmo GTW. It connects directly to the gateway's MQTT broker and sends message commands to control the associated devices. The connection is established locally, so the client must be run on the same network as the gateway. Note: internet access is not required and can be disabled on the device.
+
+Currently, the only tested and supported devices are radio shutters (Mobilus COSMO 2WAY).
 
 In order to use the client, configuration and setup need to be done on the Mobilus Cosmo GTW side. This includes creating a user and pairing the devices with the gateway.
 

--- a/mobilus_client/app.py
+++ b/mobilus_client/app.py
@@ -35,7 +35,6 @@ class App:
             if not client.connect_and_authenticate():
                 return self._empty_response()
 
-
             # Execute the provided commands
             for command, params in commands:
                 client.send_request(command, **params)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -245,3 +245,11 @@ class TestClient(unittest.TestCase):
         self.client.on_message_callback(self.client.mqtt_client, None, message)
         self.assertEqual(self.message_registry.get_responses(), [devices_list_response])
         self.assertFalse(self.client.completed_event.is_set())
+
+    def test_on_message_shared_topic_when_not_authenticated(self) -> None:
+        login_response = LoginResponseFactory(private_key=b"test_private_key")
+        devices_list_response = DevicesListResponseFactory()
+        encrypted_message = encrypt_message(devices_list_response, login_response.private_key)
+        message = Mock(payload=encrypted_message, topic="clients")
+
+        self.client.on_message_callback(self.client.mqtt_client, None, message)


### PR DESCRIPTION
When received message on shared topic, ignore it so no error is raised.

Closes #29 