### PR TITLE
Fix CI pipeline

### DIFF
--- a/mobilus_client/client.py
+++ b/mobilus_client/client.py
@@ -86,7 +86,8 @@ class Client:
             (self.shared_topic, 0),
         ])
 
-    def on_subscribe_callback(self, _client: mqtt.Client, _userdata: None, _mid: int, _granted_qos: tuple[int]) -> None:
+    def on_subscribe_callback(
+            self, _client: mqtt.Client, _userdata: None, _mid: int, _granted_qos: tuple[int, ...]) -> None:
         self.send_request(
             "login",
             login=self.config.user_login,

--- a/mobilus_client/config.py
+++ b/mobilus_client/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Literal
 
 from mobilus_client.utils.encryption import create_key
 
@@ -11,7 +12,7 @@ class Config:
 
     auth_timeout_period: float = 30
     gateway_port: int = 8884
-    gateway_protocol: str = "websockets"
+    gateway_protocol: Literal["tcp", "websockets", "unix"] = "websockets"
     timeout_period: float = 30
     user_key: bytes = b""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 [project.optional-dependencies]
 test = [
   "coverage>=7.0",
-  "factory-boy>=3.0",
+  "factory-boy==3.3.1",
   "mypy>=1.0",
   "mypy-protobuf>=3.0",
-  "ruff>=0.6.0",
+  "ruff>=0.9.0",
   "types-protobuf>=3.20"
 ]
 


### PR DESCRIPTION
- Since types-pah-mqtt are removed fix paho mqtt types that poped up
- Lock factory-boy on 3.3.1, until typing issue is solved there