### PR TITLE
feat: upgrade GitHub Actions and add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -e ".[test]"
       - name: Lint with ruff
@@ -31,10 +31,10 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install build
       - name: Build package

--- a/mobilus_client/messages/encryptor.py
+++ b/mobilus_client/messages/encryptor.py
@@ -69,7 +69,7 @@ class MessageEncryptor:
             return None
 
         # Unpack header
-        length, category, timestamp, user_id, platform, response_code = struct.unpack(
+        _length, category, timestamp, _user_id, _platform, _response_code = struct.unpack(
             header_format, encrypted_message[:header_size])
 
         # Extract encrypted body

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@ from mobilus_client.proto import (
 )
 
 
-class BaseFactory(factory.Factory):  # type: ignore[misc]
+class BaseFactory(factory.Factory): # type: ignore[misc]
     pass
 
 
@@ -63,7 +63,7 @@ class CurrentStateResponseFactory(BaseFactory):
     class Meta:
         model = CurrentStateResponse
 
-    @factory.post_generation  # type: ignore[misc]
+    @factory.post_generation # type: ignore[untyped-decorator]
     def event(self, _create: bool | None, extracted: dict[str, str | int] | None) -> None: # noqa: FBT001
         event = CurrentStateEventFactory()
 
@@ -95,7 +95,7 @@ class DevicesListResponseFactory(BaseFactory):
     class Meta:
         model = DevicesListResponse
 
-    @factory.post_generation  # type: ignore[misc]
+    @factory.post_generation # type: ignore[untyped-decorator]
     def devices(self, _create: bool | None, extracted: dict[str, str | int | bytes] | None) -> None: # noqa: FBT001
         device = DeviceFactory()
 
@@ -121,7 +121,7 @@ class CallEventsRequestFactory(BaseFactory):
     class Meta:
         model = CallEventsRequest
 
-    @factory.post_generation  # type: ignore[misc]
+    @factory.post_generation # type: ignore[untyped-decorator]
     def event(self, _create: bool | None, extracted: dict[str, str | int] | None) -> None:  # noqa: FBT001
         event = CallEventFactory()
 


### PR DESCRIPTION
- Upgrade actions/checkout from v4 to v6
- Upgrade actions/setup-python from v5 to v6
- Add Python 3.14 to test matrix
- Update default Python version to 3.14 for lint job

Fixes #40 